### PR TITLE
Bugfix: Get-EsetLink regex failure (#60)

### DIFF
--- a/IITS.ps1
+++ b/IITS.ps1
@@ -590,7 +590,7 @@ function Get-EsetLink
     [Int]$machOS=$matches[0]
     
     # RegEx the machine name to extract the group name.
-    $machName -match '\w+$' | Out-Null
+    $machName -match '[\w-]+$' | Out-Null
     [String]$groupName = $matches[0]
     }
     Process

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This file contains all of the functions that IITS distributes to all managed ser
 |Create-Zip|Darren Khan|
 |Email-MSalarm|Darren Khan|
 |External-Kaseya-Push|Michael Surtees|
+|Find-If-Domain-Blacklisted|Michael Surtees|
 |Get-All-App-Versions|Michael Surtees|
 |Get-CrashPlanLogs|Darren Khan|
 |Get-DriveChanges|Darren Khan|
@@ -18,8 +19,5 @@ This file contains all of the functions that IITS distributes to all managed ser
 |Get-ServiceAccount|Darren Khan|
 |Hide-User-From-GAL|Michael Surtees|
 |Remove-Application|Darren Khan|
-|Toggle-ActionCenter|Darren Khan|
-|Find-If-Domain-Blacklisted|Michael Surtees|
 |Remove-Outlook-Automap|Michael Surtees|
-
-
+|Toggle-ActionCenter|Darren Khan|


### PR DESCRIPTION
Failed to take dashes into account when matching for org name in Get-EsetLink (line 593). Not an issue for 99.99% of clients in Kaseya but broke on "test-org-arjun". Changed regex to "[\w-]+$" to accomodate.

Also alphabetized the Readme again, just because.